### PR TITLE
Androidでサイズの大きい画像を読み込むとOOMになる対応

### DIFF
--- a/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
+++ b/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java
@@ -182,7 +182,7 @@ public class ImageResizer {
 
             // Calculate the largest inSampleSize value that is a power of 2 and keeps both
             // height and width larger than the requested height and width.
-            while ((halfHeight / inSampleSize) >= reqHeight && (halfWidth / inSampleSize) >= reqWidth) {
+            while ((halfHeight / inSampleSize) >= reqHeight || (halfWidth / inSampleSize) >= reqWidth) {
                 inSampleSize *= 2;
             }
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40019447/44968121-db04ce00-af80-11e8-8de5-eba1e24d89b6.png)
このようなエラーが発生発生します。

Bitmapに読み込む際にmaxサイズにあわせて縮小させないといけないところが、&&になっているため5472*3678の画像では縮小されずにそのままメモリに読み込まれてOOMになります。